### PR TITLE
[SDPA-4225] update CORE to 8.8.5

### DIFF
--- a/tide_test.info.yml
+++ b/tide_test.info.yml
@@ -11,6 +11,7 @@ dependencies:
   - drupal:path
   - drupal:text
   - drupal:user
+  - drupal:ctools
   - dpc-sdp:tide_core
   - drupal:datetime
   - maxlength:maxlength

--- a/tide_test.install
+++ b/tide_test.install
@@ -35,7 +35,7 @@ function tide_test_install() {
   // happens when using minimal or testing profile).
   $default_theme = \Drupal::service('theme_handler')->getDefault();
   print 'Current theme is ' . $default_theme;
-  if (is_null($default_theme) || $default_theme == 'classy') {
+  if (is_null($default_theme) || $default_theme == 'classy' || $default_theme == 'stark') {
     \Drupal::service('theme_installer')->install(['seven']);
 
     \Drupal::configFactory()


### PR DESCRIPTION
### jira
https://digital-engagement.atlassian.net/browse/SDPA-4225

### issues
1. `Classy` theme is deprecated from Drupal 8.8.x version 
2. https://www.drupal.org/node/3083055

### changes
1. adds new default no markup theme `stark`  to the logic, but we dont want to break current tests, so still keep `classy` in the `if` expression
2. adds missing dependency `drupal/ctools`to `tide_test.info.yml` file.
3. points to Drush to 8.3.2