### PR TITLE
Bug/php 8.1 issues

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ aliases:
   - &job-build
     working_directory: /app
     docker:
-      - image: &builder-image singledigital/bay-ci-builder:4.x
+      - image: &builder-image singledigital/bay-ci-builder:5.x
         environment:
           INSTALL_NEW_SITE: 1
           LAGOON_ENVIRONMENT_TYPE: ci

--- a/tide_test.module
+++ b/tide_test.module
@@ -80,13 +80,13 @@ function tide_test_field_widget_form_alter(&$element, FormStateInterface $form_s
     if ($field_definition && $field_definition->getTargetEntityTypeId() == 'node' && $field_definition->getTargetBundle() == 'test') {
       if (TideSiteFields::isSiteField($field_definition->getName(), TideSiteFields::FIELD_SITE)) {
         $options = array_keys($element['#options']);
-        if (empty($element['#default_value']) || !count($element['#default_value'])) {
+        if (empty($element['#default_value'])) {
           $element['#default_value'] = [reset($options)];
         }
       }
 
       if (TideSiteFields::isSiteField($field_definition->getName(), TideSiteFields::FIELD_PRIMARY_SITE)) {
-        if (empty($element['#default_value']) || !count($element['#default_value'])) {
+        if (empty($element['#default_value'])) {
           $options = array_keys($element['#options']);
           $element['#default_value'] = reset($options);
         }


### PR DESCRIPTION
### JIRA

### Problem
if `$element['#default_value']` returns string count will throw error cause it can only run on array types. This causes a test content edit page to break and in results the behat test fails.

### Changes
Just check `empty()` elements should be enough as this checks for empty arrays as well.